### PR TITLE
Schema: throw exception for failed schema load

### DIFF
--- a/src/RavenTools/DbUtils/Schema.php
+++ b/src/RavenTools/DbUtils/Schema.php
@@ -144,6 +144,8 @@ class Schema {
 	 */
 	public function create() {
 
+		$db = $this->getDb();
+
 		$objects = array_merge(
 			$this->getProcedures(),
 			$this->getTables(),
@@ -152,7 +154,7 @@ class Schema {
 
 		foreach($objects as $object) {
 			printf("creating: %s %s\n",get_class($object),$object->getName());
-			$response = $this->getDb()->exec($object->getSql());
+			$response = $db->exec($object->getSql());
 			if($response === false) {
 				$message = sprintf("%s ERROR %s (%s)\n",get_class($object),$object->getName(),$db->errorInfo()[2]);
 				throw new \RuntimeException($message);

--- a/src/RavenTools/DbUtils/Schema.php
+++ b/src/RavenTools/DbUtils/Schema.php
@@ -153,6 +153,10 @@ class Schema {
 		foreach($objects as $object) {
 			printf("creating: %s %s\n",get_class($object),$object->getName());
 			$response = $this->getDb()->exec($object->getSql());
+			if($response === false) {
+				$message = sprintf("%s ERROR %s (%s)\n",get_class($object),$object->getName(),$db->errorInfo()[2]);
+				throw new \RuntimeException($message);
+			}
 		}
 	}
 


### PR DESCRIPTION
We were just ignoring table import errors when loading schema.  This throws an exception when an error is encountered.
