### PR TITLE
Schema import: index on filename rather than parsed name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cache
 vendor
 *.swp
 *.swo
+*.un~
 overrides.json
 .vagrant
 berks-cookbooks

--- a/src/RavenTools/DbUtils/Schema.php
+++ b/src/RavenTools/DbUtils/Schema.php
@@ -194,7 +194,7 @@ class Schema {
 			$full_class = sprintf('RavenTools\\DbUtils\\%s',$class);
 			$params['name'] = $name;
 			$params['path'] = sprintf("%s/%s",$this->getPath(),$object);
-			$ret[$name] = new $full_class($params);
+			$ret[$object] = new $full_class($params);
 		}
 
 		return $ret;


### PR DESCRIPTION
The parsed object name was getting overwritten in some circumstances, so use the filename to key the objects array since it should be unique.